### PR TITLE
More rds2 support

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,5 @@ init:
 
 test:
 	rm -f .coverage
-	@nosetests -sv --with-coverage ./tests/
+	@nosetests -sv --nocapture ./tests/
 

--- a/Makefile
+++ b/Makefile
@@ -6,5 +6,5 @@ init:
 
 test:
 	rm -f .coverage
-	@nosetests -sv --nocapture ./tests/
+	@nosetests -sv --with-coverage ./tests/
 

--- a/moto/rds2/models.py
+++ b/moto/rds2/models.py
@@ -158,7 +158,7 @@ class Database(object):
         return database
 
     def to_json(self):
-        template = Template(""""DBInstance": {
+        template = Template("""{
         "AllocatedStorage": 10,
         "AutoMinorVersionUpgrade": "{{ database.auto_minor_version_upgrade }}",
         "AvailabilityZone": "{{ database.availability_zone }}",
@@ -222,7 +222,10 @@ class Database(object):
         "PreferredMaintenanceWindow": "{{ database.preferred_maintenance_window }}",
         "PubliclyAccessible": "{{ database.publicly_accessible }}",
         "AllocatedStorage": "{{ database.allocated_storage }}",
-        "Endpoint": null,
+        "Endpoint": {
+            "Address": "{{ database.address }}",
+            "Port": "{{ database.port }}"
+        },
         "InstanceCreateTime": null,
         "Iops": null,
         "ReadReplicaDBInstanceIdentifiers": [{%- for replica in database.replicas -%}

--- a/moto/rds2/responses.py
+++ b/moto/rds2/responses.py
@@ -80,8 +80,7 @@ class RDS2Response(BaseResponse):
         db_kwargs = self._get_db_kwargs()
         database = self.backend.create_database(db_kwargs)
         template = self.response_template(CREATE_DATABASE_TEMPLATE)
-        result = template.render(database=database)
-        return result
+        return template.render(database=database)
 
     def create_dbinstance_read_replica(self):
         return self.create_db_instance_read_replica()
@@ -245,7 +244,7 @@ class RDS2Response(BaseResponse):
 CREATE_DATABASE_TEMPLATE = """{
   "CreateDBInstanceResponse": {
     "CreateDBInstanceResult": {
-      {{ database.to_json() }}
+      "DBInstance": {{ database.to_json() }}
     },
     "ResponseMetadata": { "RequestId": "523e3218-afc7-11c3-90f5-f90431260ab4" }
   }
@@ -261,20 +260,22 @@ CREATE_DATABASE_REPLICA_TEMPLATE = """{
 }"""
 
 DESCRIBE_DATABASES_TEMPLATE = """{
-  "DescribeDBInstanceResponse": {
-    "DescribeDBInstanceResult": [
-      {%- for database in databases -%}
-        {%- if loop.index != 1 -%},{%- endif -%}
-        { {{ database.to_json() }} }
-      {%- endfor -%}
-    ],
+  "DescribeDBInstancesResponse": {
+    "DescribeDBInstancesResult": {
+      "DBInstances": [
+        {%- for database in databases -%}
+          {%- if loop.index != 1 -%},{%- endif -%}
+          {{ database.to_json() }}
+        {%- endfor -%}
+      ]
+    },
     "ResponseMetadata": { "RequestId": "523e3218-afc7-11c3-90f5-f90431260ab4" }
   }
 }"""
 
 MODIFY_DATABASE_TEMPLATE = """{"ModifyDBInstanceResponse": {
     "ModifyDBInstanceResult": {
-      {{ database.to_json() }},
+      "DBInstance": {{ database.to_json() }},
       "ResponseMetadata": {
         "RequestId": "bb58476c-a1a8-11e4-99cf-55e92d4bbada"
       }
@@ -284,22 +285,24 @@ MODIFY_DATABASE_TEMPLATE = """{"ModifyDBInstanceResponse": {
 
 REBOOT_DATABASE_TEMPLATE = """{"RebootDBInstanceResponse": {
     "RebootDBInstanceResult": {
-      {{ database.to_json() }},
-    "ResponseMetadata": {
-      "RequestId": "d55711cb-a1ab-11e4-99cf-55e92d4bbada"
+      "DBInstance": {{ database.to_json() }},
+      "ResponseMetadata": {
+        "RequestId": "d55711cb-a1ab-11e4-99cf-55e92d4bbada"
+      }
     }
   }
-}}"""
+}"""
 
 # TODO: update delete DB TEMPLATE
 DELETE_DATABASE_TEMPLATE = """{ "DeleteDBInstanceResponse": {
     "DeleteDBInstanceResult": {
-      {{ database.to_json() }},
+      "DBInstance": {{ database.to_json() }}
+    },
     "ResponseMetadata": {
       "RequestId": "523e3218-afc7-11c3-90f5-f90431260ab4"
     }
   }
-}}"""
+}"""
 
 CREATE_SECURITY_GROUP_TEMPLATE = """<CreateDBSecurityGroupResponse xmlns="http://rds.amazonaws.com/doc/2014-09-01/">
   <CreateDBSecurityGroupResult>

--- a/tests/test_rds2/test_rds2.py
+++ b/tests/test_rds2/test_rds2.py
@@ -34,7 +34,7 @@ def test_get_databases():
     conn = boto.rds2.connect_to_region("us-west-2")
 
     instances = conn.describe_db_instances()
-    list(instances['DescribeDBInstanceResponse']['DescribeDBInstanceResult']).should.have.length_of(0)
+    list(instances['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances']).should.have.length_of(0)
 
     conn.create_db_instance(db_instance_identifier='db-master-1',
                             allocated_storage=10,
@@ -51,11 +51,11 @@ def test_get_databases():
                             master_user_password='hunter2',
                             db_security_groups=["my_sg"])
     instances = conn.describe_db_instances()
-    list(instances['DescribeDBInstanceResponse']['DescribeDBInstanceResult']).should.have.length_of(2)
+    list(instances['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances']).should.have.length_of(2)
 
     instances = conn.describe_db_instances("db-master-1")
-    list(instances['DescribeDBInstanceResponse']['DescribeDBInstanceResult']).should.have.length_of(1)
-    instances['DescribeDBInstanceResponse']['DescribeDBInstanceResult'][0]['DBInstance']['DBInstanceIdentifier'].should.equal("db-master-1")
+    list(instances['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances']).should.have.length_of(1)
+    instances['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances'][0]['DBInstanceIdentifier'].should.equal("db-master-1")
 
 
 @disable_on_py3()
@@ -77,10 +77,10 @@ def test_modify_db_instance():
                                        master_user_password='hunter2',
                                        db_security_groups=["my_sg"])
     instances = conn.describe_db_instances('db-master-1')
-    instances['DescribeDBInstanceResponse']['DescribeDBInstanceResult'][0]['DBInstance']['AllocatedStorage'].should.equal('10')
+    instances['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances'][0]['AllocatedStorage'].should.equal('10')
     conn.modify_db_instance(db_instance_identifier='db-master-1', allocated_storage=20, apply_immediately=True)
     instances = conn.describe_db_instances('db-master-1')
-    instances['DescribeDBInstanceResponse']['DescribeDBInstanceResult'][0]['DBInstance']['AllocatedStorage'].should.equal('20')
+    instances['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances'][0]['AllocatedStorage'].should.equal('20')
 
 
 @disable_on_py3()
@@ -118,7 +118,7 @@ def test_reboot_non_existant_database():
 def test_delete_database():
     conn = boto.rds2.connect_to_region("us-west-2")
     instances = conn.describe_db_instances()
-    list(instances['DescribeDBInstanceResponse']['DescribeDBInstanceResult']).should.have.length_of(0)
+    list(instances['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances']).should.have.length_of(0)
     conn.create_db_instance(db_instance_identifier='db-master-1',
                             allocated_storage=10,
                             engine='postgres',
@@ -127,11 +127,11 @@ def test_delete_database():
                             master_user_password='hunter2',
                             db_security_groups=["my_sg"])
     instances = conn.describe_db_instances()
-    list(instances['DescribeDBInstanceResponse']['DescribeDBInstanceResult']).should.have.length_of(1)
+    list(instances['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances']).should.have.length_of(1)
 
     conn.delete_db_instance("db-master-1")
     instances = conn.describe_db_instances()
-    list(instances['DescribeDBInstanceResponse']['DescribeDBInstanceResult']).should.have.length_of(0)
+    list(instances['DescribeDBInstancesResponse']['DescribeDBInstancesResult']['DBInstances']).should.have.length_of(0)
 
 
 @disable_on_py3()


### PR DESCRIPTION
Hey, here's a summary of changes;
- The biggest thing here was the change I made to the `to_json` call in `models.py`. Printing the `DBInstance` key made it a bit hard to reuse that template in lists of DBs.
- Fixed up some tests. The main thing is that some of the key structure seems to be different. These responses favor the overly verbose & nested structures.
